### PR TITLE
fix: fix ClusterRoleBinding name conflict

### DIFF
--- a/helm/grafana/templates/rbac.yaml
+++ b/helm/grafana/templates/rbac.yaml
@@ -32,7 +32,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tempostack-traces-reader-{{ include "grafana.fullname" . }}
+  name: grafana-traces-reader-{{ include "grafana.fullname" . }}
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
Refs: https://github.com/rh-ai-kickstart/lls-observability/issues/4

Adjust name of ClusterRoleBinging in grafana helm chart to avoid conflict