### PR TITLE
Remote metrics property and add namespace filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 observability/
 CLAUDE.*
 .claude*
+
+.idea/
+*.iml

--- a/helm/02-observability/otel-collector/clusterrole.yaml
+++ b/helm/02-observability/otel-collector/clusterrole.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: tempostack-traces-write
 rules:
+  # Tempo trace writing permissions
   - apiGroups:
       - 'tempo.grafana.com'
     resources:
@@ -12,6 +13,16 @@ rules:
       - traces
     verbs:
       - 'create'
+  # k8sattributes processor permissions
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/02-observability/otel-collector/otel-collector-llamastack-sidecar.yaml
+++ b/helm/02-observability/otel-collector/otel-collector-llamastack-sidecar.yaml
@@ -32,9 +32,6 @@ spec:
             - otlphttp
           receivers:
             - otlp
-      telemetry:
-        metrics:
-          address: '0.0.0.0:8888'
   mode: sidecar
   resources: {}
   podDnsConfig: {}

--- a/helm/02-observability/otel-collector/otel-collector-vllm-sidecar.yaml
+++ b/helm/02-observability/otel-collector/otel-collector-vllm-sidecar.yaml
@@ -46,10 +46,7 @@ spec:
             - otlphttp
           receivers:
             - prometheus
-            - otlp
-      telemetry:
-        metrics:
-          address: '0.0.0.0:8888'
+              - otlp
   mode: sidecar
   resources: {}
   podDnsConfig: {}

--- a/helm/02-observability/otel-collector/otel-collector.yaml
+++ b/helm/02-observability/otel-collector/otel-collector.yaml
@@ -51,6 +51,9 @@ spec:
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
+        extract:
+          metadata:
+            - k8s.namespace.name
       batch:
         send_batch_size: 100
         timeout: 1s

--- a/helm/02-observability/otel-collector/otel-collector.yaml
+++ b/helm/02-observability/otel-collector/otel-collector.yaml
@@ -78,6 +78,3 @@ spec:
           exporters:
             - debug
             - otlphttp/dev
-      telemetry:
-        metrics:
-          address: 0.0.0.0:8888

--- a/helm/02-observability/otel-collector/otel-collector.yaml
+++ b/helm/02-observability/otel-collector/otel-collector.yaml
@@ -48,6 +48,9 @@ spec:
             endpoint: 0.0.0.0:4318
 
     processors:
+      k8sattributes:
+        filter:
+          node_from_env_var: KUBE_NODE_NAME
       batch:
         send_batch_size: 100
         timeout: 1s
@@ -73,6 +76,7 @@ spec:
           receivers:
             - otlp
           processors:
+            - k8sattributes
             - batch
             - memory_limiter
           exporters:

--- a/helm/02-observability/otel-collector/templates/otel-collector-llamastack-sidecar.yaml
+++ b/helm/02-observability/otel-collector/templates/otel-collector-llamastack-sidecar.yaml
@@ -57,7 +57,4 @@ spec:
             - otlphttp
           receivers:
             - otlp
-      telemetry:
-        metrics:
-          address: '0.0.0.0:8888'
 {{- end }}

--- a/helm/02-observability/otel-collector/templates/otel-collector-vllm-sidecar.yaml
+++ b/helm/02-observability/otel-collector/templates/otel-collector-vllm-sidecar.yaml
@@ -71,8 +71,5 @@ spec:
             - otlphttp
           receivers:
             - prometheus
-            - otlp
-      telemetry:
-        metrics:
-          address: '0.0.0.0:8888'
+              - otlp
 {{- end }}

--- a/helm/02-observability/otel-collector/values.yaml
+++ b/helm/02-observability/otel-collector/values.yaml
@@ -32,6 +32,7 @@ rbac:
     # Name of the ClusterRole for writing traces to Tempo
     name: "tempostack-traces-write"
     rules:
+      # Tempo trace writing permissions
       - apiGroups:
           - 'tempo.grafana.com'
         resources:
@@ -40,6 +41,16 @@ rbac:
           - traces
         verbs:
           - 'create'
+      # k8sattributes processor permissions
+      - apiGroups: [""]
+        resources:
+          - pods
+          - namespaces
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
 
 # Main OpenTelemetry Collector configuration
 collector:
@@ -130,6 +141,9 @@ collector:
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
+        extract:
+          metadata:
+            - k8s.namespace.name
       batch:
         send_batch_size: 100
         timeout: 1s

--- a/helm/02-observability/otel-collector/values.yaml
+++ b/helm/02-observability/otel-collector/values.yaml
@@ -127,6 +127,9 @@ collector:
     
     # Processors configuration
     processors:
+      k8sattributes:
+        filter:
+          node_from_env_var: KUBE_NODE_NAME
       batch:
         send_batch_size: 100
         timeout: 1s
@@ -153,6 +156,7 @@ collector:
           receivers:
             - otlp
           processors:
+            - k8sattributes
             - batch
             - memory_limiter
           exporters:

--- a/helm/02-observability/otel-collector/values.yaml
+++ b/helm/02-observability/otel-collector/values.yaml
@@ -158,9 +158,6 @@ collector:
           exporters:
             - debug
             - otlphttp/dev
-      telemetry:
-        metrics:
-          address: 0.0.0.0:8888
 
 # Tempo configuration for exporters
 tempo:
@@ -229,7 +226,7 @@ sidecars:
               - otlp
         telemetry:
           metrics:
-            address: '0.0.0.0:8888'
+            listen_address: '0.0.0.0:8888'
     
     # Target allocator configuration
     targetAllocator:
@@ -295,9 +292,6 @@ sidecars:
             receivers:
               - prometheus
               - otlp
-        telemetry:
-          metrics:
-            address: '0.0.0.0:8888'
     
     # Target allocator configuration
     targetAllocator:


### PR DESCRIPTION
1. Remove telemetry / metrics property (that makes the deploy failining)
2. Add k8sattributes filter
 
See https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/red_hat_build_of_opentelemetry/configuring-the-collector#otel-processors-kubernetes-attributes-processor_otel-collector-processors