### PR TITLE
Xeon Support (SPR+) for LLS Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ https://github.com/rh-ai-quickstart/lls-observability.git && \
 cd lls-observability
 ```
 
-# Build vllm-xeon-opentelemetry Image (Xeon deployments)
+### Build vllm-xeon-opentelemetry Image (Xeon deployments)
 ```bash
 # ImageStream
 oc create imagestream vllm-xeon-opentelemetry -n openshift

--- a/README.md
+++ b/README.md
@@ -130,14 +130,14 @@ These traces provide insights into:
 ## Deploy
 
 ```bash
-# step 0 - git clone
-https://github.com/rh-ai-quickstart/lls-observability.git && \ 
+# step 0 
+git clone https://github.com/rh-ai-quickstart/lls-observability.git && \ 
 cd lls-observability
 ```
 
-### Quick Start - Automated Installation
-
-#### Xeon deployment -build vllm-xeon-opentelemetry
+### Prerequisites
+#### Xeon deployment
+- Build vllm-xeon-opentelemetry Image
 ```bash
 # ImageStream
 oc create imagestream vllm-xeon-opentelemetry -n openshift
@@ -146,6 +146,8 @@ oc apply -f helm/vllm-xeon-opentelemetry-build-config.yaml
 # Wait ~5 minutes and check if image is present in OpenShift
 oc get is -n openshift | grep vllm-xeon-opentelemetry
 ```
+
+### Quick Start - Automated Installation
 
 **Option 1: Complete Stack (Recommended)**
 ```bash

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ https://github.com/rh-ai-quickstart/lls-observability.git && \
 cd lls-observability
 ```
 
-### Build vllm-xeon-opentelemetry Image (Xeon deployments)
+### Quick Start - Automated Installation
+
+#### Xeon deployment -build vllm-xeon-opentelemetry
 ```bash
 # ImageStream
 oc create imagestream vllm-xeon-opentelemetry -n openshift
@@ -144,9 +146,6 @@ oc apply -f helm/vllm-xeon-opentelemetry-build-config.yaml
 # Wait ~5 minutes and check if image is present in OpenShift
 oc get is -n openshift | grep vllm-xeon-opentelemetry
 ```
-
-### Quick Start - Automated Installation
-
 
 **Option 1: Complete Stack (Recommended)**
 ```bash

--- a/README.md
+++ b/README.md
@@ -107,7 +107,13 @@ These traces provide insights into:
 - **CPU**: 8+ cores recommended for full stack deployment
 - **Memory**: 16GB+ RAM for monitoring stack, additional memory based on AI workload requirements
 - **Storage**: 100GB+ for observability data retention
-- **GPU**: NVIDIA GPU required for AI model inference (varies by model size)
+- **Inference Hardware**
+  - **GPU** *(Default)*: NVIDIA GPU required for AI model inference (varies by model size)
+  - **Xeon**:
+    - 2 worker nodes with Intel Xeon processor 4th gen or newer (SPR, EMR, GNR) with a minimum of 32vCPU and 64GB of RAM
+      - Llama3.2-3b requires at least 16vCPU and 32GB of memory
+      - Lllama-Guard (Llama-Guard-3-1B) requires at least 4vCPU and 16GB of memory
+      - for example: m8i.8xlarge, m7i.8xlarge, c8i.8xlarge
 
 ### Minimum software requirements
 
@@ -119,7 +125,7 @@ These traces provide insights into:
 ### Required user permissions
 
 - **Cluster Admin** - Required for operator installation and observability stack setup
-- **GPU Access** - Required for AI workload deployment
+- **GPU Access** - Required for AI workload deployment on GPU
 
 ## Deploy
 
@@ -129,6 +135,16 @@ https://github.com/rh-ai-quickstart/lls-observability.git && \
 cd lls-observability
 ```
 
+# Build vllm-xeon-opentelemetry Image (Xeon deployments)
+```bash
+# ImageStream
+oc create imagestream vllm-xeon-opentelemetry -n openshift
+# BuildConfig
+oc apply -f helm/vllm-xeon-opentelemetry-build-config.yaml
+# Wait ~5 minutes and check if image is present in OpenShift
+oc get is -n openshift | grep vllm-xeon-opentelemetry
+```
+
 ### Quick Start - Automated Installation
 
 
@@ -136,10 +152,15 @@ cd lls-observability
 ```bash
 # Run the full installation script
 ./scripts/install-full-stack.sh
+# Xeon
+DEVICE=xeon scripts/install-full-stack.sh
 ```
 
 **Option 2: Phase-by-Phase Installation**
 ```bash
+# For Xeon Deployments set DEVICE environment variable
+# export DEVICE=xeon
+
 # Phase 1: Install operators
 ./scripts/install-operators.sh
 
@@ -152,6 +173,9 @@ cd lls-observability
 
 **Option 3: Using Makefile (Optional)**
 ```bash
+# Xeon Deployments
+# export DEVICE=xeon
+
 # Install everything in one command
 make install-all
 
@@ -173,6 +197,10 @@ Set these environment variables before running the installation commands:
 export OBSERVABILITY_NAMESPACE="observability-hub"
 export UWM_NAMESPACE="openshift-user-workload-monitoring"
 export AI_SERVICES_NAMESPACE="llama-serve"
+
+# Need to explicitly set DEVICE deployment
+export DEVICE=GPU # or xeon
+
 ```
 
 Launch this instructions:
@@ -216,17 +244,17 @@ helm install hr-api ./helm/04-mcp-servers/hr-api -n ${AI_SERVICES_NAMESPACE}
 # Deploy AI services in AI services namespace  
 helm install llama3-2-3b ./helm/03-ai-services/llama3.2-3b -n ${AI_SERVICES_NAMESPACE} \
   --set model.name="meta-llama/Llama-3.2-3B-Instruct" \
-  --set resources.limits."nvidia\.com/gpu"=1
+  --set device="$DEVICE"
 
 helm install llama-stack-instance ./helm/03-ai-services/llama-stack-instance -n ${AI_SERVICES_NAMESPACE} \
   --set 'mcpServers[0].name=weather' \
   --set 'mcpServers[0].uri=http://mcp-weather.${AI_SERVICES_NAMESPACE}.svc.cluster.local:80' \
   --set 'mcpServers[0].description=Weather MCP Server for real-time weather data'
 
-helm install llama-stack-playground ./helm/03-ai-services/llama-stack-playground -n ${AI_SERVICES_NAMESPACE} \
-  --set playground.llamaStackUrl="http://llama-stack-instance.${AI_SERVICES_NAMESPACE}.svc.cluster.local:80"
+helm install llama-stack-playground ./helm/03-ai-services/llama-stack-playground -n ${AI_SERVICES_NAMESPACE}
 
-helm install llama-guard ./helm/03-ai-services/llama-guard -n ${AI_SERVICES_NAMESPACE}
+helm install llama-guard ./helm/03-ai-services/llama-guard -n ${AI_SERVICES_NAMESPACE} \
+  --set device="$DEVICE"
 
 # 7. Enable tracing UI
 helm install distributed-tracing-ui-plugin ./helm/02-observability/distributed-tracing-ui-plugin

--- a/helm/02-observability/otel-collector/otel-collector-llamastack-sidecar.yaml
+++ b/helm/02-observability/otel-collector/otel-collector-llamastack-sidecar.yaml
@@ -34,7 +34,7 @@ spec:
             - otlp
       telemetry:
         metrics:
-          address: '0.0.0.0:8888'
+          level: detailed
   mode: sidecar
   resources: {}
   podDnsConfig: {}

--- a/helm/02-observability/otel-collector/otel-collector-vllm-sidecar.yaml
+++ b/helm/02-observability/otel-collector/otel-collector-vllm-sidecar.yaml
@@ -49,7 +49,7 @@ spec:
             - otlp
       telemetry:
         metrics:
-          address: '0.0.0.0:8888'
+          level: detailed
   mode: sidecar
   resources: {}
   podDnsConfig: {}

--- a/helm/02-observability/otel-collector/otel-collector.yaml
+++ b/helm/02-observability/otel-collector/otel-collector.yaml
@@ -39,7 +39,7 @@ spec:
               scrape_interval: 15s
               static_configs:
                 - targets:
-                    - 'llama3-2-3b-predictor.llama-serve.svc.cluster.local:8080'
+                    - 'llama3-2-3b-predictor.llama-serve.svc.cluster.local:80'
       otlp:
         protocols:
           grpc:
@@ -80,4 +80,4 @@ spec:
             - otlphttp/dev
       telemetry:
         metrics:
-          address: 0.0.0.0:8888
+          level: detailed

--- a/helm/02-observability/otel-collector/templates/otel-collector-llamastack-sidecar.yaml
+++ b/helm/02-observability/otel-collector/templates/otel-collector-llamastack-sidecar.yaml
@@ -59,5 +59,5 @@ spec:
             - otlp
       telemetry:
         metrics:
-          address: '0.0.0.0:8888'
+          level: detailed
 {{- end }}

--- a/helm/02-observability/otel-collector/templates/otel-collector-vllm-sidecar.yaml
+++ b/helm/02-observability/otel-collector/templates/otel-collector-vllm-sidecar.yaml
@@ -74,5 +74,5 @@ spec:
             - otlp
       telemetry:
         metrics:
-          address: '0.0.0.0:8888'
+          level: detailed
 {{- end }}

--- a/helm/02-observability/otel-collector/values.yaml
+++ b/helm/02-observability/otel-collector/values.yaml
@@ -117,7 +117,7 @@ collector:
               scrape_interval: 15s
               static_configs:
                 - targets:
-                    - 'llama3-2-3b-predictor.llama-serve.svc.cluster.local:8080'
+                    - 'llama3-2-3b-predictor.llama-serve.svc.cluster.local:80'
       otlp:
         protocols:
           grpc:
@@ -160,7 +160,7 @@ collector:
             - otlphttp/dev
       telemetry:
         metrics:
-          address: 0.0.0.0:8888
+          level: detailed
 
 # Tempo configuration for exporters
 tempo:
@@ -184,7 +184,7 @@ prometheus:
       jobName: "llama3-2-3b"
       scrapeInterval: "15s"
       targets:
-        - "llama3-2-3b-predictor.llama-serve.svc.cluster.local:8080"
+        - "llama3-2-3b-predictor.llama-serve.svc.cluster.local:80"
 
 # Sidecar configurations
 sidecars:
@@ -229,7 +229,7 @@ sidecars:
               - otlp
         telemetry:
           metrics:
-            address: '0.0.0.0:8888'
+            level: detailed
     
     # Target allocator configuration
     targetAllocator:
@@ -297,7 +297,7 @@ sidecars:
               - otlp
         telemetry:
           metrics:
-            address: '0.0.0.0:8888'
+            level: detailed
     
     # Target allocator configuration
     targetAllocator:

--- a/helm/03-ai-services/llama-guard/templates/inferenceservice.yaml
+++ b/helm/03-ai-services/llama-guard/templates/inferenceservice.yaml
@@ -22,8 +22,8 @@ spec:
         name: {{ .Values.inferenceService.modelFormat | default "vLLM" }}
       name: {{ .Values.inferenceService.modelName | default "" }}
       resources:
-        {{- toYaml .Values.resources | nindent 8 }}
+        {{- toYaml (index .Values.resources .Values.device) | nindent 8 }}
       runtime: llama-guard-3-1b
       storageUri: {{ .Values.inferenceService.storageUri | default "oci://quay.io/rh-aiservices-bu/llama-guard-3-1b-modelcar:2.0.0" }}
     tolerations:
-      {{- toYaml .Values.tolerations | nindent 6 }}
+      {{- toYaml (index .Values.tolerations .Values.device) | nindent 6 }}

--- a/helm/03-ai-services/llama-guard/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama-guard/templates/servingruntime.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.servingRuntime.enabled }}
+{{- $device := lower (.Values.device | default "gpu") }}
+{{- $image := index .Values.image $device }}
+{{- $resources := index .Values.resources $device }}
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
@@ -7,7 +10,9 @@ metadata:
     {{- include "llama-guard.labels" . | nindent 4 }}
   annotations:
     opendatahub.io/apiProtocol: REST
+    {{- if eq $device "gpu" }}
     opendatahub.io/accelerator-name: migrated-gpu
+    {{- end }}
 spec:
   supportedModelFormats:
   - name: vLLM
@@ -18,12 +23,15 @@ spec:
     autoSelect: true
   containers:
   - name: kserve-container
-    image: {{ .Values.servingRuntime.image | default "quay.io/modh/vllm@sha256:4f550996130e7d16cacb24ca9a2865e7cf51eddaab014ceaf31a1ea6ef86d4ec" }}
+    image: {{ (index $image "repository") }}:{{ (index $image "tag") }}
+    imagePullPolicy: {{ default "IfNotPresent" (index $image "pullPolicy") }}
     args:
     - --model=/mnt/models
     - --port=8080
     - --max-model-len={{ .Values.model.maxModelLen | default 8192 }}
+    {{- if eq $device "gpu" }}
     - --gpu_memory_utilization={{ .Values.model.gpuMemoryUtilization | default 0.40 }}
+    {{- end }}
     - '--served-model-name={{ .Values.model.name | default "meta-llama/Llama-Guard-3-1B" }}'
     - --distributed-executor-backend={{ .Values.servingRuntime.distributedExecutorBackend | default "mp" }}
     - --dtype={{ .Values.model.dtype | default "half" }}
@@ -54,7 +62,7 @@ spec:
       name: h2c
       protocol: TCP
     resources:
-      {{- toYaml .Values.resources | nindent 6 }}
+      {{- toYaml $resources | nindent 6 }}
     volumeMounts:
     - name: shm
       mountPath: /dev/shm
@@ -63,17 +71,17 @@ spec:
     emptyDir:
       medium: Memory
       sizeLimit: {{ .Values.servingRuntime.shmSizeLimit | default "2Gi" }}
-  {{- with .Values.nodeSelector }}
+  {{- if and .Values.nodeSelector (hasKey .Values.nodeSelector $device) }}
   nodeSelector:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (index .Values.nodeSelector $device) | nindent 4 }}
   {{- end }}
-  {{- with .Values.affinity }}
+  {{- if and .Values.affinity (hasKey .Values.affinity $device) }}
   affinity:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (index .Values.affinity $device) | nindent 4 }}
   {{- end }}
-  {{- with .Values.tolerations }}
+  {{- if and .Values.tolerations (hasKey .Values.tolerations $device) }}
   tolerations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (index .Values.tolerations $device) | nindent 4 }}
   {{- end }}
   builtInAdapter:
     serverType: vllm

--- a/helm/03-ai-services/llama-guard/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama-guard/templates/servingruntime.yaml
@@ -51,7 +51,7 @@ spec:
     - name: OTEL_EXPORTER_OTLP_TRACES_INSECURE
       value: {{ .Values.servingRuntime.tracing.insecure | quote }}
     {{- end }}
-    {{- range $key, $value := .Values.env }}
+    {{- range $key, $value := index $image "env" }}
     {{- if ne $key "HF_HOME" }}
     - name: {{ $key }}
       value: {{ $value | quote }}

--- a/helm/03-ai-services/llama-guard/values.yaml
+++ b/helm/03-ai-services/llama-guard/values.yaml
@@ -12,8 +12,7 @@ image:
       TRANSFORMERS_CACHE: "/tmp/hf_home"
       HF_HOME: "/tmp/hf_home"
   xeon:
-    # TODO: Change hardoced llama-serve namespace
-    repository: "image-registry.openshift-image-registry.svc:5000/llama-serve/vllm-xeon-opentelemetry"
+    repository: "image-registry.openshift-image-registry.svc:5000/openshift/vllm-xeon-opentelemetry"
     tag: "v0.14.1-ubi9"
     pullPolicy: IfNotPresent
     env:

--- a/helm/03-ai-services/llama-guard/values.yaml
+++ b/helm/03-ai-services/llama-guard/values.yaml
@@ -1,10 +1,25 @@
 # Default values for llama-guard
 replicaCount: 1
 
+device: gpu # Options: gpu, xeon
 image:
-  repository: 'quay.io/modh/vllm@sha256:'
-  tag: "4f550996130e7d16cacb24ca9a2865e7cf51eddaab014ceaf31a1ea6ef86d4ec"
-  pullPolicy: IfNotPresent
+  gpu:
+    repository: "quay.io/modh/vllm@sha256"
+    tag: "4f550996130e7d16cacb24ca9a2865e7cf51eddaab014ceaf31a1ea6ef86d4ec"
+    pullPolicy: IfNotPresent
+    env:
+      CUDA_VISIBLE_DEVICES: "0"
+      TRANSFORMERS_CACHE: "/tmp/hf_home"
+      HF_HOME: "/tmp/hf_home"
+  xeon:
+    # TODO: Change hardoced llama-serve namespace
+    repository: "image-registry.openshift-image-registry.svc:5000/llama-serve/vllm-xeon-opentelemetry"
+    tag: "v0.14.1-ubi9"
+    pullPolicy: IfNotPresent
+    env:
+      VLLM_CPU_KVCACHE_SPACE: 4
+      TRANSFORMERS_CACHE: "/tmp/hf_home"
+      HF_HOME: "/tmp/hf_home"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -84,14 +99,22 @@ ingress:
 
 # Resource requirements (adjust based on GPU availability)
 resources:
-  limits:
-    nvidia.com/gpu: 1
-    memory: 10Gi
-    cpu: 8
-  requests:
-    nvidia.com/gpu: 1
-    memory: 8Gi
-    cpu: 1
+  gpu:
+    requests:
+      nvidia.com/gpu: 1
+      memory: 8Gi
+      cpu: 4
+    limits:
+      nvidia.com/gpu: 1
+      memory: 10Gi
+      cpu: 8
+  xeon:
+    requests:
+      cpu: 4
+      memory: 16Gi
+    limits:
+      cpu: 16
+      memory: 32Gi
 
 livenessProbe:
   httpGet:
@@ -116,22 +139,44 @@ autoscaling:
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 
+# For Xeon deployments, you can use node selectors, tolerations and affinity to target appropriate nodes,
+# when your cluster has a mix of older and newer CPU generations.
+# Adjust these based on your cluster's labeling and tainting strategy.
 nodeSelector:
-  nvidia.com/gpu.present: "true"
+  gpu:
+    nvidia.com/gpu.present: "true"
+# xeon:
+#   intel.com/cpu-gen: "spr"
+#   intel.com/cpu-gen: "emr"
+#   intel.com/cpu-gen: "gnr"
 
 tolerations:
+  gpu:
   - effect: NoSchedule
     operator: Exists
+# xeon:
+# - effect: NoSchedule
+#   operator: Exists
 
 affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: nvidia.com/gpu.present
-          operator: In
-          values:
-          - "true"
+  gpu:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nvidia.com/gpu.present
+            operator: In
+            values:
+            - "true"
+# xeon:
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         # Use taints and labels to target specific CPU generations for optimal performance
+#         - key: intel.com/cpu-gen
+#           operator: In
+#           values: ["spr", "emr", "gnr"]
 
 # Persistent Volume for model cache
 persistence:
@@ -140,12 +185,6 @@ persistence:
   accessMode: ReadWriteOnce
   size: 10Gi
   mountPath: /tmp/hf_home
-
-# Environment variables
-env:
-  CUDA_VISIBLE_DEVICES: "0"
-  TRANSFORMERS_CACHE: "/tmp/hf_home"
-  HF_HOME: "/tmp/hf_home"
 
 # InferenceService configuration
 inferenceService:
@@ -160,7 +199,6 @@ inferenceService:
 # Serving Runtime configuration
 servingRuntime:
   enabled: true  # Set to true to create a ServingRuntime resource
-  image: "quay.io/modh/vllm@sha256:4f550996130e7d16cacb24ca9a2865e7cf51eddaab014ceaf31a1ea6ef86d4ec"
   tensorParallelSize: 1
   shmSizeLimit: "2Gi"
   memBufferBytes: 134217728  # 128MB

--- a/helm/03-ai-services/llama-stack-instance/templates/configmap.yaml
+++ b/helm/03-ai-services/llama-stack-instance/templates/configmap.yaml
@@ -24,14 +24,14 @@ data:
       - provider_id: vllm-inference
         provider_type: remote::vllm
         config:
-          url: {{ .Values.llamaStackDistribution.vllmUrl | default "http://llama3-2-3b-predictor:8080/v1" | quote }}
+          url: {{ .Values.llamaStackDistribution.vllmUrl | default "http://llama3-2-3b-predictor/v1" | quote }}
           max_tokens: {{ .Values.llamaStackDistribution.vllmMaxTokens | default 60000 }}
           api_token: {{ .Values.llamaStackDistribution.vllmApiToken | default "fake" | quote }}
           tls_verify: {{ .Values.llamaStackDistribution.vllmTlsVerify | default false }}
       - provider_id: vllm-safety
         provider_type: remote::vllm
         config:
-          url: {{ .Values.llamaStackDistribution.safetyUrl | default "http://llama-guard-3-1b-predictor:8080/v1" | quote }}
+          url: {{ .Values.llamaStackDistribution.safetyUrl | default "http://llama-guard-3-1b-predictor/v1" | quote }}
           max_tokens: {{ .Values.llamaStackDistribution.safetyMaxTokens | default 20000 }}
           api_token: {{ .Values.llamaStackDistribution.vllmApiToken | default "fake" | quote }}
           tls_verify: {{ .Values.llamaStackDistribution.safetyTlsVerify | default false }}

--- a/helm/03-ai-services/llama-stack-instance/templates/llamastackdistribution.yaml
+++ b/helm/03-ai-services/llama-stack-instance/templates/llamastackdistribution.yaml
@@ -30,9 +30,9 @@ spec:
         - name: VLLM_MAX_TOKENS
           value: "60000"
         - name: VLLM_URL
-          value: "http://llama3-2-3b-predictor:8080/v1"
+          value: "http://llama3-2-3b-predictor/v1"
         - name: SAFETY_URL
-          value: "http://llama-guard-3-1b-predictor:8080/v1"
+          value: "http://llama-guard-3-1b-predictor/v1"
         - name: VLLM_API_TOKEN
           value: "fake"
         - name: VLLM_TLS_VERIFY

--- a/helm/03-ai-services/llama-stack-playground/values.yaml
+++ b/helm/03-ai-services/llama-stack-playground/values.yaml
@@ -100,7 +100,7 @@ affinity: {}
 # Playground configuration
 playground:
   # Llama Stack backend URL
-  llamaStackUrl: "http://llama-stack"
+  llamaStackUrl: "http://llama-stack-instance-service:8321"
   # Default model to use
   defaultModel: "meta-llama/Llama-3.2-3B-Instruct"
   # Enable/disable features

--- a/helm/03-ai-services/llama3.2-3b/files/tool_chat_template_llama3.2_json.jinja
+++ b/helm/03-ai-services/llama3.2-3b/files/tool_chat_template_llama3.2_json.jinja
@@ -1,0 +1,133 @@
+{{- bos_token }}
+{%- if custom_tools is defined %}
+    {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools_in_user_message is defined %}
+    {%- set tools_in_user_message = false %}
+{%- endif %}
+{%- if not date_string is defined %}
+    {%- if strftime_now is defined %}
+        {%- set date_string = strftime_now("%d %b %Y") %}
+    {%- else %}
+        {%- set date_string = "26 Jul 2024" %}
+    {%- endif %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+
+{#- Find out if there are any images #}
+{% set image_ns = namespace(has_images=false) %}
+{%- for message in messages %}
+    {%- for content in message['content'] %}
+        {%- if content['type'] == 'image' %}
+            {%- set image_ns.has_images = true %}
+        {%- endif %}
+    {%- endfor %}
+{%- endfor %}
+
+{#- This block extracts the system message, so we can slot it into the right place. #}
+{%- if messages[0]['role'] == 'system' %}
+    {%- if messages[0]['content'] is string %}
+        {%- set system_message = messages[0]['content']|trim %}
+    {%- else %}
+        {%- set system_message = messages[0]['content'][0]['text']|trim %}
+    {%- endif %}
+    {%- set messages = messages[1:] %}
+{%- else %}
+    {%- if tools is not none %}
+        {%- set system_message = "You are a helpful assistant with tool calling capabilities. Only reply with a tool call if the function exists in the library provided by the user. If it doesn't exist, just reply directly in natural language. When you receive a tool call response, use the output to format an answer to the original user question." %}
+    {%- else %}
+        {%- set system_message = "" %}
+    {%- endif %}
+{%- endif %}
+
+{#- System message if there are no images, if the user supplied one, or if tools are used (default tool system message) #}
+{%- if system_message or not image_ns.has_images %}
+    {{- "<|start_header_id|>system<|end_header_id|>\n\n" }}
+    {%- if tools is not none %}
+        {{- "Environment: ipython\n" }}
+    {%- endif %}
+    {{- "Cutting Knowledge Date: December 2023\n" }}
+    {{- "Today Date: " + date_string + "\n\n" }}
+    {%- if tools is not none and not tools_in_user_message %}
+        {{- "You have access to the following functions. To call a function, please respond with JSON for a function call. " }}
+        {{- 'Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}. ' }}
+        {{- "Do not use variables.\n\n" }}
+        {%- for t in tools %}
+            {{- t | tojson(indent=4) }}
+            {{- "\n\n" }}
+        {%- endfor %}
+    {%- endif %}
+    {{- system_message }}
+    {{- "<|eot_id|>" }}
+{%- endif %}
+
+{#- Custom tools are passed in a user message with some extra guidance #}
+{%- if tools_in_user_message and not tools is none %}
+    {#- Extract the first user message so we can plug it in here #}
+    {%- if messages | length != 0 %}
+        {%- if messages[0]['content'] is string %}
+            {%- set first_user_message = messages[0]['content']|trim %}
+        {%- else %}
+            {%- set first_user_message = messages[0]['content'] | selectattr('type', 'equalto', 'text') | map(attribute='text') | map('trim') | join('\n') %}
+        {%- endif %}
+        {%- set messages = messages[1:] %}
+    {%- else %}
+        {{- raise_exception("Cannot put tools in the first user message when there's no first user message!") }}
+    {%- endif %}
+    {{- '<|start_header_id|>user<|end_header_id|>\n\n' -}}
+    {{- "Given the following functions, please respond with a JSON for a function call " }}
+    {{- "with its proper arguments that best answers the given prompt.\n\n" }}
+    {{- 'Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}. ' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+    {{- first_user_message + "<|eot_id|>"}}
+{%- endif %}
+
+{%- for message in messages %}
+    {%- if not (message.role == 'ipython' or message.role == 'tool' or 'tool_calls' in message) %}
+        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n' }}
+        {%- if message['content'] is string %}
+            {{- message['content'] | trim}}
+        {%- else %}
+            {%- for content in message['content'] %}
+                {%- if content['type'] == 'image' %}
+                    {{- '<|image|>' }}
+                {%- elif content['type'] == 'text' %}
+                    {{- content['text'] | trim }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|eot_id|>' }}
+    {%- elif 'tool_calls' in message %}
+        {%- if not message.tool_calls|length == 1 %}
+            {{- raise_exception("This model only supports single tool-calls at once!") }}
+        {%- endif %}
+        {%- set tool_call = message.tool_calls[0].function %}
+        {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
+        {{- '{"name": "' + tool_call.name + '", ' }}
+        {{- '"parameters": ' }}
+        {{- tool_call.arguments | tojson }}
+        {{- "}" }}
+        {{- "<|eot_id|>" }}
+    {%- elif message.role == "tool" or message.role == "ipython" %}
+        {{- "<|start_header_id|>ipython<|end_header_id|>\n\n" }}
+        {%- if message.content is string %}
+            {{- { "output": message.content } | tojson }}
+        {%- else %}
+            {%- for content in message['content']  %}
+                {%- if content['type']  == 'text' %}
+                    {{- { "output": content['text']  } | tojson }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- "<|eot_id|>" }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+{%- endif %}

--- a/helm/03-ai-services/llama3.2-3b/templates/configmap-chat-template.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/configmap-chat-template.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.servingRuntime.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "llama3-2-3b.fullname" . }}-chat-template
+  labels:
+    {{- include "llama3-2-3b.labels" . | nindent 4 }}
+data:
+  tool_chat_template_llama3.2_json.jinja: |
+{{ .Files.Get "files/tool_chat_template_llama3.2_json.jinja" | nindent 4 }}
+{{- end }}

--- a/helm/03-ai-services/llama3.2-3b/templates/inferenceservice.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/inferenceservice.yaml
@@ -14,6 +14,9 @@ metadata:
   finalizers:
     - serving.kserve.io/inferenceservice-finalizer
 spec:
+  {{- $device := lower (.Values.device | default "gpu") }}
+  {{- $resources := index .Values.resources $device }}
+  {{- $tolerations := index .Values.tolerations $device }}
   predictor:
     maxReplicas: {{ .Values.inferenceService.maxReplicas | default 1 }}
     minReplicas: {{ .Values.inferenceService.minReplicas | default 1 }}
@@ -22,8 +25,10 @@ spec:
         name: {{ .Values.inferenceService.modelFormat | default "vLLM" }}
       name: {{ .Values.inferenceService.modelName | default "" }}
       resources:
-        {{- toYaml .Values.resources | nindent 8 }}
+        {{- toYaml $resources | nindent 8 }}
       runtime: llama3-2-3b
       storageUri: {{ .Values.inferenceService.storageUri | default "oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-3b-instruct" }}
+    {{- if $tolerations }}
     tolerations:
-      {{- toYaml .Values.tolerations | nindent 6 }}
+      {{- toYaml $tolerations | nindent 6 }}
+    {{- end }}

--- a/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
@@ -26,7 +26,9 @@ spec:
     - --model=/mnt/models
     - --port=8080
     - --max-model-len={{ .Values.model.maxModelLen | default 8192 }}
+    {{- if eq $device "gpu" }}
     - --gpu_memory_utilization={{ .Values.model.gpuMemoryUtilization | default 0.95 }}
+    {{- end }}
     - '--served-model-name=llama3-2-3b'
     - --chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja
     - '--enable-auto-tool-choice'

--- a/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
@@ -18,7 +18,10 @@ spec:
     autoSelect: true
   containers:
   - name: kserve-container
-    image: {{ .Values.servingRuntime.image | default "quay.io/modh/vllm@sha256:0d55419f3d168fd80868a36ac89815dded9e063937a8409b7edf3529771383f3" }}
+    {{- $device := lower (.Values.device | default "gpu") }}
+    {{- $image := index .Values.image $device }}
+    image: "{{ (index $image "repository") }}:{{ (index $image "tag") }}"
+    imagePullPolicy: {{ default "IfNotPresent" (index $image "pullPolicy") }}
     args:
     - --model=/mnt/models
     - --port=8080

--- a/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
@@ -20,6 +20,7 @@ spec:
   - name: kserve-container
     {{- $device := lower (.Values.device | default "gpu") }}
     {{- $image := index .Values.image $device }}
+    {{- $resources := index .Values.resources $device }}
     image: "{{ (index $image "repository") }}:{{ (index $image "tag") }}"
     imagePullPolicy: {{ default "IfNotPresent" (index $image "pullPolicy") }}
     args:
@@ -61,7 +62,7 @@ spec:
       name: h2c
       protocol: TCP
     resources:
-      {{- toYaml .Values.resources | nindent 6 }}
+      {{- toYaml $resources | nindent 6 }}
     volumeMounts:
     - name: shm
       mountPath: /dev/shm
@@ -70,17 +71,17 @@ spec:
     emptyDir:
       medium: Memory
       sizeLimit: {{ .Values.servingRuntime.shmSizeLimit | default "1Gi" }}
-  {{- with .Values.nodeSelector }}
+  {{- if and .Values.nodeSelector (hasKey .Values.nodeSelector $device) }}
   nodeSelector:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (index .Values.nodeSelector $device) | nindent 4 }}
   {{- end }}
-  {{- with .Values.affinity }}
+  {{- if and .Values.affinity (hasKey .Values.affinity $device) }}
   affinity:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (index .Values.affinity $device) | nindent 4 }}
   {{- end }}
-  {{- with .Values.tolerations }}
+  {{- if and .Values.tolerations (hasKey .Values.tolerations $device) }}
   tolerations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (index .Values.tolerations $device) | nindent 4 }}
   {{- end }}
   builtInAdapter:
     serverType: vllm

--- a/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
@@ -11,7 +11,9 @@ metadata:
     {{- include "llama3-2-3b.labels" . | nindent 4 }}
   annotations:
     opendatahub.io/apiProtocol: REST
+    {{- if eq $device "gpu" }}
     opendatahub.io/accelerator-name: migrated-gpu
+    {{ - end }}
 spec:
   supportedModelFormats:
   - name: vLLM

--- a/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
@@ -69,25 +69,21 @@ spec:
     volumeMounts:
     - name: shm
       mountPath: /dev/shm
-    {{- if eq $device "xeon" }}
     - name: chat-template
       mountPath: {{ $chatTemplate | quote }}
       subPath: tool_chat_template_llama3.2_json.jinja
       readOnly: true
-    {{- end }}
   volumes:
   - name: shm
     emptyDir:
       medium: Memory
       sizeLimit: {{ .Values.servingRuntime.shmSizeLimit | default "1Gi" }}
-  {{- if eq $device "xeon" }}
   - name: chat-template
     configMap:
       name: {{ include "llama3-2-3b.fullname" . }}-chat-template
       items:
       - key: tool_chat_template_llama3.2_json.jinja
         path: tool_chat_template_llama3.2_json.jinja
-  {{- end }}
   {{- if and .Values.nodeSelector (hasKey .Values.nodeSelector $device) }}
   nodeSelector:
     {{- toYaml (index .Values.nodeSelector $device) | nindent 4 }}

--- a/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
@@ -13,7 +13,7 @@ metadata:
     opendatahub.io/apiProtocol: REST
     {{- if eq $device "gpu" }}
     opendatahub.io/accelerator-name: migrated-gpu
-    {{ - end }}
+    {{- end }}
 spec:
   supportedModelFormats:
   - name: vLLM
@@ -54,8 +54,7 @@ spec:
     - name: OTEL_EXPORTER_OTLP_TRACES_INSECURE
       value: {{ .Values.servingRuntime.tracing.insecure | quote }}
     {{- end }}
-    {{- $env := index $image "env" | default dict }}
-    {{- range $key, $value := $env }}
+    {{- range $key, $value := index $image "env" }}
     {{- if ne $key "HF_HOME" }}
     - name: {{ $key }}
       value: {{ $value | quote }}

--- a/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.servingRuntime.enabled }}
+{{- $device := lower (.Values.device | default "gpu") }}
+{{- $image := index .Values.image $device }}
+{{- $resources := index .Values.resources $device }}
+{{- $chatTemplate := index $image "chatTemplate" | default "/app/data/template/tool_chat_template_llama3.2_json.jinja" }}
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
@@ -18,10 +22,7 @@ spec:
     autoSelect: true
   containers:
   - name: kserve-container
-    {{- $device := lower (.Values.device | default "gpu") }}
-    {{- $image := index .Values.image $device }}
-    {{- $resources := index .Values.resources $device }}
-    image: "{{ (index $image "repository") }}:{{ (index $image "tag") }}"
+    image: {{ (index $image "repository") }}:{{ (index $image "tag") }}
     imagePullPolicy: {{ default "IfNotPresent" (index $image "pullPolicy") }}
     args:
     - --model=/mnt/models
@@ -30,10 +31,10 @@ spec:
     {{- if eq $device "gpu" }}
     - --gpu_memory_utilization={{ .Values.model.gpuMemoryUtilization | default 0.95 }}
     {{- end }}
-    - '--served-model-name=llama3-2-3b'
-    - --chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja
-    - '--enable-auto-tool-choice'
-    - '--tool-call-parser'
+    - --served-model-name=llama3-2-3b
+    - --chat-template={{ $chatTemplate }}
+    - --enable-auto-tool-choice
+    - --tool-call-parser
     - llama3_json
     {{- if .Values.servingRuntime.tracing.enabled }}
     # tracing-specific flags and options
@@ -51,7 +52,8 @@ spec:
     - name: OTEL_EXPORTER_OTLP_TRACES_INSECURE
       value: {{ .Values.servingRuntime.tracing.insecure | quote }}
     {{- end }}
-    {{- range $key, $value := .Values.env }}
+    {{- $env := index $image "env" | default dict }}
+    {{- range $key, $value := $env }}
     {{- if ne $key "HF_HOME" }}
     - name: {{ $key }}
       value: {{ $value | quote }}
@@ -66,11 +68,25 @@ spec:
     volumeMounts:
     - name: shm
       mountPath: /dev/shm
+    {{- if eq $device "xeon" }}
+    - name: chat-template
+      mountPath: {{ $chatTemplate | quote }}
+      subPath: tool_chat_template_llama3.2_json.jinja
+      readOnly: true
+    {{- end }}
   volumes:
   - name: shm
     emptyDir:
       medium: Memory
       sizeLimit: {{ .Values.servingRuntime.shmSizeLimit | default "1Gi" }}
+  {{- if eq $device "xeon" }}
+  - name: chat-template
+    configMap:
+      name: {{ include "llama3-2-3b.fullname" . }}-chat-template
+      items:
+      - key: tool_chat_template_llama3.2_json.jinja
+        path: tool_chat_template_llama3.2_json.jinja
+  {{- end }}
   {{- if and .Values.nodeSelector (hasKey .Values.nodeSelector $device) }}
   nodeSelector:
     {{- toYaml (index .Values.nodeSelector $device) | nindent 4 }}

--- a/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
+++ b/helm/03-ai-services/llama3.2-3b/templates/servingruntime.yaml
@@ -2,7 +2,7 @@
 {{- $device := lower (.Values.device | default "gpu") }}
 {{- $image := index .Values.image $device }}
 {{- $resources := index .Values.resources $device }}
-{{- $chatTemplate := index $image "chatTemplate" | default "/app/data/template/tool_chat_template_llama3.2_json.jinja" }}
+{{- $chatTemplate := index $image "chatTemplate" }}
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:

--- a/helm/03-ai-services/llama3.2-3b/values.yaml
+++ b/helm/03-ai-services/llama3.2-3b/values.yaml
@@ -95,14 +95,22 @@ ingress:
 
 # Resource requirements (adjust based on GPU availability)
 resources:
-  limits:
-    nvidia.com/gpu: 1
-    memory: 24Gi
-    cpu: 4
-  requests:
-    nvidia.com/gpu: 1
-    memory: 16Gi
-    cpu: 2
+  gpu:
+    requests:
+      nvidia.com/gpu: 1
+      memory: 16Gi
+      cpu: 2
+    limits:
+      nvidia.com/gpu: 1
+      memory: 24Gi
+      cpu: 4
+  xeon:
+    requests:
+      cpu: 16
+      memory: 64Gi
+    limits:
+      cpu: 32
+      memory: 64Gi
 
 livenessProbe:
   httpGet:
@@ -129,21 +137,40 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
 
 nodeSelector:
-  nvidia.com/gpu.present: "true"
+  gpu:
+    nvidia.com/gpu.present: "true"
+  # xeon:
+  #   intel.com/cpu-gen: "spr
+  #   intel.com/cpu-gen: "emr"
+  #   intel.com/cpu-gen: "gnr"
 
 tolerations:
+  gpu:
   - effect: NoSchedule
     operator: Exists
+  # xeon:
+  # - effect: NoSchedule
+  #   operator: Exists
 
 affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: nvidia.com/gpu.present
-          operator: In
-          values:
-          - "true"
+  gpu:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nvidia.com/gpu.present
+            operator: In
+            values:
+            - "true"
+  # xeon:
+  #   nodeAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #       nodeSelectorTerms:
+  #       - matchExpressions:
+  #         # Use taints and labels to target specific CPU generations for optimal performance
+  #         - key: intel.com/cpu-gen
+  #           operator: In
+  #           values: ["spr", "emr", "gnr"]
 
 # Persistent Volume for model cache
 persistence:

--- a/helm/03-ai-services/llama3.2-3b/values.yaml
+++ b/helm/03-ai-services/llama3.2-3b/values.yaml
@@ -1,12 +1,19 @@
 # Default values for llama3.2-3b
 replicaCount: 1
 
+device: "gpu"  # Options: gpu, xeon
 image:
-  # repository: 'quay.io/modh/vllm@sha256:'
-  # tag: "0d55419f3d168fd80868a36ac89815dded9e063937a8409b7edf3529771383f3"
-  repository: 'quay.io/rcarrata/vllm-otlp-tracing@sha256:'
-  tag: "16f83f5858fcc04bd56ea785126c04af823e8aacbeabb9db963f86d252178189"
-  pullPolicy: IfNotPresent
+  gpu:
+    # repository: 'quay.io/modh/vllm@sha256:'
+    # tag: "0d55419f3d168fd80868a36ac89815dded9e063937a8409b7edf3529771383f3"
+    repository: 'quay.io/rcarrata/vllm-otlp-tracing@sha256'
+    tag: "16f83f5858fcc04bd56ea785126c04af823e8aacbeabb9db963f86d252178189"
+    pullPolicy: IfNotPresent
+  xeon:
+    repository: 'docker.io/opea/vllm-cpu-ubi'
+    tag: "v0.12.0-ubi9"
+    pullPolicy: IfNotPresent
+
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/03-ai-services/llama3.2-3b/values.yaml
+++ b/helm/03-ai-services/llama3.2-3b/values.yaml
@@ -152,7 +152,7 @@ nodeSelector:
   gpu:
     nvidia.com/gpu.present: "true"
 # xeon:
-#   intel.com/cpu-gen: "spr
+#   intel.com/cpu-gen: "spr"
 #   intel.com/cpu-gen: "emr"
 #   intel.com/cpu-gen: "gnr"
 

--- a/helm/03-ai-services/llama3.2-3b/values.yaml
+++ b/helm/03-ai-services/llama3.2-3b/values.yaml
@@ -4,7 +4,6 @@ replicaCount: 1
 device: "gpu"  # Options: gpu, xeon
 image:
   gpu:
-
     repository: "quay.io/rcarrata/vllm-otlp-tracing@sha256"
     tag: "16f83f5858fcc04bd56ea785126c04af823e8aacbeabb9db963f86d252178189"
     pullPolicy: IfNotPresent

--- a/helm/03-ai-services/llama3.2-3b/values.yaml
+++ b/helm/03-ai-services/llama3.2-3b/values.yaml
@@ -4,8 +4,7 @@ replicaCount: 1
 device: "gpu"  # Options: gpu, xeon
 image:
   gpu:
-    # repository: 'quay.io/modh/vllm@sha256:'
-    # tag: "0d55419f3d168fd80868a36ac89815dded9e063937a8409b7edf3529771383f3"
+
     repository: "quay.io/rcarrata/vllm-otlp-tracing@sha256"
     tag: "16f83f5858fcc04bd56ea785126c04af823e8aacbeabb9db963f86d252178189"
     pullPolicy: IfNotPresent
@@ -17,11 +16,14 @@ image:
     repository: 'image-registry.openshift-image-registry.svc:5000/llama-serve/vllm-xeon-opentelemetry'
     tag: "v0.14.1-ubi9"
     pullPolicy: IfNotPresent
+    chatTemplate: "/app/data/template/tool_chat_template_llama3.2_json.jinja"
     env:
       HOME: /tmp
       XDG_CACHE_HOME: /tmp/.cache
       VLLM_CACHE_ROOT: /tmp/.cache/vllm
       VLLM_CPU_KVCACHE_SPACE: "16"
+      TRANSFORMERS_CACHE: "/tmp/hf_home"
+      HF_HOME: "/tmp/hf_home"
 
 
 imagePullSecrets: []

--- a/helm/03-ai-services/llama3.2-3b/values.yaml
+++ b/helm/03-ai-services/llama3.2-3b/values.yaml
@@ -6,13 +6,22 @@ image:
   gpu:
     # repository: 'quay.io/modh/vllm@sha256:'
     # tag: "0d55419f3d168fd80868a36ac89815dded9e063937a8409b7edf3529771383f3"
-    repository: 'quay.io/rcarrata/vllm-otlp-tracing@sha256'
+    repository: "quay.io/rcarrata/vllm-otlp-tracing@sha256"
     tag: "16f83f5858fcc04bd56ea785126c04af823e8aacbeabb9db963f86d252178189"
     pullPolicy: IfNotPresent
+    chatTemplate: "/app/data/template/tool_chat_template_llama3.2_json.jinja"
+    env:
+      CUDA_VISIBLE_DEVICES: "0"
+      HF_HOME: "/root/.cache/huggingface"
   xeon:
-    repository: 'docker.io/opea/vllm-cpu-ubi'
-    tag: "v0.12.0-ubi9"
+    repository: 'image-registry.openshift-image-registry.svc:5000/llama-serve/vllm-xeon-opentelemetry'
+    tag: "v0.14.1-ubi9"
     pullPolicy: IfNotPresent
+    env:
+      HOME: /tmp
+      XDG_CACHE_HOME: /tmp/.cache
+      VLLM_CACHE_ROOT: /tmp/.cache/vllm
+      VLLM_CPU_KVCACHE_SPACE: "16"
 
 
 imagePullSecrets: []
@@ -107,7 +116,7 @@ resources:
   xeon:
     requests:
       cpu: 16
-      memory: 64Gi
+      memory: 32Gi
     limits:
       cpu: 32
       memory: 64Gi
@@ -136,21 +145,24 @@ autoscaling:
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 
+# For Xeon deployments, you can use node selectors, tolerations and affinity to target appropriate nodes,
+# when your cluster has a mix of older and newer CPU generations.
+# Adjust these based on your cluster's labeling and tainting strategy.
 nodeSelector:
   gpu:
     nvidia.com/gpu.present: "true"
-  # xeon:
-  #   intel.com/cpu-gen: "spr
-  #   intel.com/cpu-gen: "emr"
-  #   intel.com/cpu-gen: "gnr"
+# xeon:
+#   intel.com/cpu-gen: "spr
+#   intel.com/cpu-gen: "emr"
+#   intel.com/cpu-gen: "gnr"
 
 tolerations:
   gpu:
   - effect: NoSchedule
     operator: Exists
-  # xeon:
-  # - effect: NoSchedule
-  #   operator: Exists
+# xeon:
+# - effect: NoSchedule
+#   operator: Exists
 
 affinity:
   gpu:
@@ -162,15 +174,15 @@ affinity:
             operator: In
             values:
             - "true"
-  # xeon:
-  #   nodeAffinity:
-  #     requiredDuringSchedulingIgnoredDuringExecution:
-  #       nodeSelectorTerms:
-  #       - matchExpressions:
-  #         # Use taints and labels to target specific CPU generations for optimal performance
-  #         - key: intel.com/cpu-gen
-  #           operator: In
-  #           values: ["spr", "emr", "gnr"]
+# xeon:
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         # Use taints and labels to target specific CPU generations for optimal performance
+#         - key: intel.com/cpu-gen
+#           operator: In
+#           values: ["spr", "emr", "gnr"]
 
 # Persistent Volume for model cache
 persistence:
@@ -179,12 +191,6 @@ persistence:
   accessMode: ReadWriteOnce
   size: 50Gi
   mountPath: /root/.cache
-
-# Environment variables
-env:
-  CUDA_VISIBLE_DEVICES: "0"
-  TRANSFORMERS_CACHE: "/root/.cache/huggingface"
-  HF_HOME: "/root/.cache/huggingface"
 
 # InferenceService configuration
 inferenceService:
@@ -199,7 +205,6 @@ inferenceService:
 # Serving Runtime configuration
 servingRuntime:
   enabled: true  # Set to true to create a ServingRuntime resource
-  image: "quay.io/modh/vllm@sha256:0d55419f3d168fd80868a36ac89815dded9e063937a8409b7edf3529771383f3"
   tensorParallelSize: 1
   shmSizeLimit: "1Gi"
   memBufferBytes: 134217728  # 128MB

--- a/helm/03-ai-services/llama3.2-3b/values.yaml
+++ b/helm/03-ai-services/llama3.2-3b/values.yaml
@@ -13,7 +13,7 @@ image:
       CUDA_VISIBLE_DEVICES: "0"
       HF_HOME: "/root/.cache/huggingface"
   xeon:
-    repository: 'image-registry.openshift-image-registry.svc:5000/llama-serve/vllm-xeon-opentelemetry'
+    repository: 'image-registry.openshift-image-registry.svc:5000/openshift/vllm-xeon-opentelemetry'
     tag: "v0.14.1-ubi9"
     pullPolicy: IfNotPresent
     chatTemplate: "/app/data/template/tool_chat_template_llama3.2_json.jinja"
@@ -22,9 +22,6 @@ image:
       XDG_CACHE_HOME: /tmp/.cache
       VLLM_CACHE_ROOT: /tmp/.cache/vllm
       VLLM_CPU_KVCACHE_SPACE: "16"
-      TRANSFORMERS_CACHE: "/tmp/hf_home"
-      HF_HOME: "/tmp/hf_home"
-
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm/vllm-xeon-opentelemetry-build-config.yaml
+++ b/helm/vllm-xeon-opentelemetry-build-config.yaml
@@ -2,7 +2,7 @@ apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: vllm-xeon-opentelemetry
-  namespace: llama-serve
+  namespace: openshift
 spec:
   source:
     dockerfile: |

--- a/helm/vllm-xeon-opentelemetry-build-config.yaml
+++ b/helm/vllm-xeon-opentelemetry-build-config.yaml
@@ -1,0 +1,31 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: vllm-xeon-opentelemetry
+  namespace: llama-serve
+spec:
+  source:
+    dockerfile: |
+      # Use the vllm-cpu-ubi image as the base
+      FROM docker.io/opea/vllm-cpu-ubi:v0.14.1-ubi9
+
+      USER 0
+
+      # Install OpenTelemetry packages
+      RUN pip install \
+          "opentelemetry-sdk>=1.26.0,<1.27.0" \
+          "opentelemetry-api>=1.26.0,<1.27.0" \
+          "opentelemetry-exporter-otlp>=1.26.0,<1.27.0" \
+          "opentelemetry-semantic-conventions-ai>=0.4.1,<0.5.0"
+
+      USER 1001
+  strategy:
+    type: Docker
+    dockerStrategy: {}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: vllm-xeon-opentelemetry:v0.14.1-ubi9
+  runPolicy: SerialLatestOnly
+  triggers:
+  - type: ConfigChange

--- a/scripts/deploy-ai-workloads.sh
+++ b/scripts/deploy-ai-workloads.sh
@@ -8,6 +8,9 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+# Supported values: "gpu" or "xeon"
+DEVICE="${DEVICE:-gpu}"
+
 print_status() {
     echo -e "${GREEN}[INFO]${NC} $1"
 }
@@ -71,10 +74,10 @@ print_status "Step 3: Deploying AI services..."
 # Deploy llama3.2-3b with GPU configuration
 if [ -d "$HELM_DIR/03-ai-services/llama3.2-3b" ]; then
     if ! release_exists "llama3-2-3b" "$AI_SERVICES_NAMESPACE"; then
-        print_status "Installing llama3.2-3b with GPU support in $AI_SERVICES_NAMESPACE..."
+        print_status "Installing llama3.2-3b with $DEVICE support in $AI_SERVICES_NAMESPACE..."
         helm install llama3-2-3b "$HELM_DIR/03-ai-services/llama3.2-3b" -n "$AI_SERVICES_NAMESPACE" \
             --set model.name="meta-llama/Llama-3.2-3B-Instruct" \
-            --set resources.limits."nvidia\.com/gpu"=1
+            --set device="$DEVICE"
     else
         print_warning "llama3-2-3b already installed, skipping..."
     fi
@@ -103,8 +106,7 @@ fi
 if [ -d "$HELM_DIR/03-ai-services/llama-stack-playground" ]; then
     if ! release_exists "llama-stack-playground" "$AI_SERVICES_NAMESPACE"; then
         print_status "Installing llama-stack-playground in $AI_SERVICES_NAMESPACE..."
-        helm install llama-stack-playground "$HELM_DIR/03-ai-services/llama-stack-playground" -n "$AI_SERVICES_NAMESPACE" \
-            --set playground.llamaStackUrl="http://llama-stack-instance.llama-serve.svc.cluster.local:80"
+        helm install llama-stack-playground "$HELM_DIR/03-ai-services/llama-stack-playground" -n "$AI_SERVICES_NAMESPACE"
     else
         print_warning "llama-stack-playground already installed, skipping..."
     fi
@@ -116,7 +118,8 @@ fi
 if [ -d "$HELM_DIR/03-ai-services/llama-guard" ]; then
     if ! release_exists "llama-guard" "$AI_SERVICES_NAMESPACE"; then
         print_status "Installing llama-guard in $AI_SERVICES_NAMESPACE..."
-        helm install llama-guard "$HELM_DIR/03-ai-services/llama-guard" -n "$AI_SERVICES_NAMESPACE"
+        helm install llama-guard "$HELM_DIR/03-ai-services/llama-guard" -n "$AI_SERVICES_NAMESPACE" \
+            --set device="$DEVICE"
     else
         print_warning "llama-guard already installed, skipping..."
     fi
@@ -128,6 +131,7 @@ print_status "AI workloads deployment completed!"
 
 echo ""
 echo "Deployment summary:"
+echo "- Device type: $DEVICE"
 echo "- MCP Servers: weather, hr-api, openshift-mcp (in $AI_SERVICES_NAMESPACE namespace)"
 echo "- AI Services: llama3.2-3b, llama-stack-instance (with inline Milvus), playground, llama-guard (in $AI_SERVICES_NAMESPACE namespace)"
 echo ""

--- a/scripts/install-full-stack.sh
+++ b/scripts/install-full-stack.sh
@@ -33,18 +33,9 @@ print_error() {
 create_namespaces() {
     print_status "Creating required namespaces..."
     
-    # Workload namespaces
     oc create namespace $OBSERVABILITY_NAMESPACE --dry-run=client -o yaml | oc apply -f-
     oc create namespace openshift-user-workload-monitoring --dry-run=client -o yaml | oc apply -f-
     oc create namespace $AI_SERVICES_NAMESPACE --dry-run=client -o yaml | oc apply -f-
-    oc create namespace $OPERATOR_RELEASE_NAMESPACE --dry-run=client -o yaml | oc apply -f-
-
-    # Operator namespaces — pre-create so operator charts don't need to manage them
-    for ns in openshift-cluster-observability-operator openshift-grafana-operator \
-              openshift-opentelemetry-operator openshift-tempo-operator \
-              llama-stack-k8s-operator-system; do
-        oc create namespace "$ns" --dry-run=client -o yaml | oc apply -f-
-    done
     
     print_status "Namespaces created successfully"
 }
@@ -54,7 +45,11 @@ release_exists() {
     local release_name=$1
     local namespace=${2:-$DEFAULT_NAMESPACE}
 
-    helm list -q -n "$namespace" | grep -q "^${release_name}$"
+    if [ "$namespace" = "$DEFAULT_NAMESPACE" ]; then
+        helm list -q | grep -q "^${release_name}$"
+    else
+        helm list -q -n "$namespace" | grep -q "^${release_name}$"
+    fi
 }
 
 # Function to install charts in a directory
@@ -67,7 +62,7 @@ install_charts_in_directory() {
         print_warning "Directory $HELM_DIR/$dir not found, skipping..."
         return
     fi
-    
+
     print_status "Installing charts from $dir..."
 
     local pids=()
@@ -83,20 +78,22 @@ install_charts_in_directory() {
             fi
             
             print_status "Installing $chart_name..."
-
-            # For operator charts, skip namespace creation (pre-created in create_namespaces)
-            local helm_extra_args=()
-            if [ "$dir" = "01-operators" ]; then
-                helm_extra_args+=(--set namespace.create=false)
-            fi
             
             if [ "$parallel" = "true" ]; then
                 # Install in background for parallel execution
-                helm install "$chart_name" "$chart_dir" -n "$namespace" "${helm_extra_args[@]}" &
+                if [ "$namespace" = "$DEFAULT_NAMESPACE" ]; then
+                    helm install "$chart_name" "$chart_dir" &
+                else
+                    helm install "$chart_name" "$chart_dir" -n "$namespace" &
+                fi
                 pids+=($!)
             else
                 # Install sequentially
-                helm install "$chart_name" "$chart_dir" -n "$namespace" "${helm_extra_args[@]}"
+                if [ "$namespace" = "$DEFAULT_NAMESPACE" ]; then
+                    helm install "$chart_name" "$chart_dir"
+                else
+                    helm install "$chart_name" "$chart_dir" -n "$namespace"
+                fi
             fi
         fi
     done
@@ -231,7 +228,7 @@ install_ai_workloads() {
     
     # Install llama3.2-3b with GPU or Xeon configuration
     if ! release_exists "llama3-2-3b" "$AI_SERVICES_NAMESPACE"; then
-        print_status "Installing llama3.2-3b with GPU or Xeon support in $AI_SERVICES_NAMESPACE..."
+        print_status "Installing llama3.2-3b with $DEVICE support in $AI_SERVICES_NAMESPACE..."
         helm install llama3-2-3b "$HELM_DIR/03-ai-services/llama3.2-3b" -n "$AI_SERVICES_NAMESPACE" \
             --set model.name="meta-llama/Llama-3.2-3B-Instruct" \
             --set device="$DEVICE"
@@ -275,13 +272,13 @@ main() {
     echo "  Llama Stack Observability Installer"
     echo "========================================"
     echo ""
-    
+
     # Check if we're in the right directory
     if [ ! -d "$HELM_DIR" ]; then
         print_error "Helm directory not found. Please run this script from the repository root."
         exit 1
     fi
-    
+
     print_status "Starting full stack installation..."
     print_status "Using device type: $DEVICE"
     echo ""
@@ -290,23 +287,23 @@ main() {
     print_status "Phase 1: Creating namespaces"
     create_namespaces
     echo ""
-    
+
     # Phase 2: Install operators
     print_status "Phase 2: Installing operators"
-    install_charts_in_directory "01-operators" "$OPERATOR_RELEASE_NAMESPACE" "true"
+    install_charts_in_directory "01-operators" "$DEFAULT_NAMESPACE" "true"
     echo ""
-    
+
     # Phase 3: Wait for operators
     print_status "Phase 3: Waiting for operators to be ready"
     wait_for_operators
     echo ""
-    
+
     # Phase 4: Deploy observability infrastructure
     print_status "Phase 4: Deploying observability infrastructure"
-    
+
     # Deploy charts in specific order, skipping distributed-tracing-ui-plugin initially
     charts_order=("tempo" "otel-collector" "grafana")
-    
+
     for chart_name in "${charts_order[@]}"; do
         chart_dir="$HELM_DIR/02-observability/$chart_name"
         if [ -d "$chart_dir" ] && [ -f "$chart_dir/Chart.yaml" ]; then

--- a/scripts/install-full-stack.sh
+++ b/scripts/install-full-stack.sh
@@ -10,10 +10,12 @@ NC='\033[0m' # No Color
 
 # Configuration
 HELM_DIR="./helm"
-OBSERVABILITY_NAMESPACE="observability-hub"
-AI_SERVICES_NAMESPACE="llama-serve"
-DEFAULT_NAMESPACE="default"
-DEVICE_TYPE="gpu" # Supported values: "gpu" or "xeon"
+OBSERVABILITY_NAMESPACE="${OBSERVABILITY_NAMESPACE:-observability-hub}"
+AI_SERVICES_NAMESPACE="${AI_SERVICES_NAMESPACE:-llama-serve}"
+DEFAULT_NAMESPACE="${DEFAULT_NAMESPACE:-default}"
+OPERATOR_RELEASE_NAMESPACE="${OPERATOR_RELEASE_NAMESPACE:-lls-observability}"
+DEVICE="${DEVICE:-gpu}" # Supported values: "gpu" or "xeon"
+
 # Function to print colored output
 print_status() {
     echo -e "${GREEN}[INFO]${NC} $1"
@@ -31,9 +33,18 @@ print_error() {
 create_namespaces() {
     print_status "Creating required namespaces..."
     
+    # Workload namespaces
     oc create namespace $OBSERVABILITY_NAMESPACE --dry-run=client -o yaml | oc apply -f-
     oc create namespace openshift-user-workload-monitoring --dry-run=client -o yaml | oc apply -f-
     oc create namespace $AI_SERVICES_NAMESPACE --dry-run=client -o yaml | oc apply -f-
+    oc create namespace $OPERATOR_RELEASE_NAMESPACE --dry-run=client -o yaml | oc apply -f-
+
+    # Operator namespaces — pre-create so operator charts don't need to manage them
+    for ns in openshift-cluster-observability-operator openshift-grafana-operator \
+              openshift-opentelemetry-operator openshift-tempo-operator \
+              llama-stack-k8s-operator-system; do
+        oc create namespace "$ns" --dry-run=client -o yaml | oc apply -f-
+    done
     
     print_status "Namespaces created successfully"
 }
@@ -42,12 +53,8 @@ create_namespaces() {
 release_exists() {
     local release_name=$1
     local namespace=${2:-$DEFAULT_NAMESPACE}
-    
-    if [ "$namespace" = "$DEFAULT_NAMESPACE" ]; then
-        helm list -q | grep -q "^${release_name}$"
-    else
-        helm list -q -n "$namespace" | grep -q "^${release_name}$"
-    fi
+
+    helm list -q -n "$namespace" | grep -q "^${release_name}$"
 }
 
 # Function to install charts in a directory
@@ -62,9 +69,9 @@ install_charts_in_directory() {
     fi
     
     print_status "Installing charts from $dir..."
-    
+
     local pids=()
-    
+
     for chart_dir in "$HELM_DIR/$dir"/*; do
         if [ -d "$chart_dir" ] && [ -f "$chart_dir/Chart.yaml" ]; then
             chart_name=$(basename "$chart_dir")
@@ -76,22 +83,20 @@ install_charts_in_directory() {
             fi
             
             print_status "Installing $chart_name..."
+
+            # For operator charts, skip namespace creation (pre-created in create_namespaces)
+            local helm_extra_args=()
+            if [ "$dir" = "01-operators" ]; then
+                helm_extra_args+=(--set namespace.create=false)
+            fi
             
             if [ "$parallel" = "true" ]; then
                 # Install in background for parallel execution
-                if [ "$namespace" = "$DEFAULT_NAMESPACE" ]; then
-                    helm install "$chart_name" "$chart_dir" &
-                else
-                    helm install "$chart_name" "$chart_dir" -n "$namespace" &
-                fi
+                helm install "$chart_name" "$chart_dir" -n "$namespace" "${helm_extra_args[@]}" &
                 pids+=($!)
             else
                 # Install sequentially
-                if [ "$namespace" = "$DEFAULT_NAMESPACE" ]; then
-                    helm install "$chart_name" "$chart_dir"
-                else
-                    helm install "$chart_name" "$chart_dir" -n "$namespace"
-                fi
+                helm install "$chart_name" "$chart_dir" -n "$namespace" "${helm_extra_args[@]}"
             fi
         fi
     done
@@ -224,14 +229,12 @@ install_ai_workloads() {
     # Using inline Milvus - no external deployment needed
     print_status "Using inline Milvus (configured within llama-stack-instance)..."
     
-    # Install llama3.2-3b with GPU configuration
+    # Install llama3.2-3b with GPU or Xeon configuration
     if ! release_exists "llama3-2-3b" "$AI_SERVICES_NAMESPACE"; then
-        print_status "Installing llama3.2-3b with $DEVICE_TYPE support in $AI_SERVICES_NAMESPACE..."
-
+        print_status "Installing llama3.2-3b with GPU or Xeon support in $AI_SERVICES_NAMESPACE..."
         helm install llama3-2-3b "$HELM_DIR/03-ai-services/llama3.2-3b" -n "$AI_SERVICES_NAMESPACE" \
             --set model.name="meta-llama/Llama-3.2-3B-Instruct" \
-            --set device="$DEVICE_TYPE" \
-
+            --set device="$DEVICE"
     else
         print_warning "llama3-2-3b already installed, skipping..."
     fi
@@ -248,8 +251,7 @@ install_ai_workloads() {
     # Install playground
     if ! release_exists "llama-stack-playground" "$AI_SERVICES_NAMESPACE"; then
         print_status "Installing llama-stack-playground in $AI_SERVICES_NAMESPACE..."
-        helm install llama-stack-playground "$HELM_DIR/03-ai-services/llama-stack-playground" -n "$AI_SERVICES_NAMESPACE" \
-            --set playground.llamaStackUrl="http://llama-stack-instance.llama-serve.svc.cluster.local:80"
+        helm install llama-stack-playground "$HELM_DIR/03-ai-services/llama-stack-playground" -n "$AI_SERVICES_NAMESPACE"
     else
         print_warning "llama-stack-playground already installed, skipping..."
     fi
@@ -259,7 +261,8 @@ install_ai_workloads() {
         if ! release_exists "llama-guard" "$AI_SERVICES_NAMESPACE"; then
             print_status "Installing llama-guard in $AI_SERVICES_NAMESPACE..."
             helm install llama-guard "$HELM_DIR/03-ai-services/llama-guard" -n "$AI_SERVICES_NAMESPACE" \
-                --set device="$DEVICE_TYPE"
+                --set device="$DEVICE"
+
         else
             print_warning "llama-guard already installed, skipping..."
         fi
@@ -280,7 +283,9 @@ main() {
     fi
     
     print_status "Starting full stack installation..."
-    
+    print_status "Using device type: $DEVICE"
+    echo ""
+
     # Phase 1: Create namespaces
     print_status "Phase 1: Creating namespaces"
     create_namespaces
@@ -288,7 +293,7 @@ main() {
     
     # Phase 2: Install operators
     print_status "Phase 2: Installing operators"
-    install_charts_in_directory "01-operators" "$DEFAULT_NAMESPACE" "true"
+    install_charts_in_directory "01-operators" "$OPERATOR_RELEASE_NAMESPACE" "true"
     echo ""
     
     # Phase 3: Wait for operators

--- a/scripts/install-full-stack.sh
+++ b/scripts/install-full-stack.sh
@@ -13,7 +13,7 @@ HELM_DIR="./helm"
 OBSERVABILITY_NAMESPACE="observability-hub"
 AI_SERVICES_NAMESPACE="llama-serve"
 DEFAULT_NAMESPACE="default"
-
+DEVICE_TYPE="gpu" # Supported values: "gpu" or "xeon"
 # Function to print colored output
 print_status() {
     echo -e "${GREEN}[INFO]${NC} $1"
@@ -226,10 +226,12 @@ install_ai_workloads() {
     
     # Install llama3.2-3b with GPU configuration
     if ! release_exists "llama3-2-3b" "$AI_SERVICES_NAMESPACE"; then
-        print_status "Installing llama3.2-3b with GPU support in $AI_SERVICES_NAMESPACE..."
+        print_status "Installing llama3.2-3b with $DEVICE_TYPE support in $AI_SERVICES_NAMESPACE..."
+
         helm install llama3-2-3b "$HELM_DIR/03-ai-services/llama3.2-3b" -n "$AI_SERVICES_NAMESPACE" \
             --set model.name="meta-llama/Llama-3.2-3B-Instruct" \
-            --set resources.limits."nvidia\.com/gpu"=1
+            --set device="$DEVICE_TYPE" \
+
     else
         print_warning "llama3-2-3b already installed, skipping..."
     fi

--- a/scripts/install-full-stack.sh
+++ b/scripts/install-full-stack.sh
@@ -258,7 +258,8 @@ install_ai_workloads() {
     if [ -d "$HELM_DIR/03-ai-services/llama-guard" ]; then
         if ! release_exists "llama-guard" "$AI_SERVICES_NAMESPACE"; then
             print_status "Installing llama-guard in $AI_SERVICES_NAMESPACE..."
-            helm install llama-guard "$HELM_DIR/03-ai-services/llama-guard" -n "$AI_SERVICES_NAMESPACE"
+            helm install llama-guard "$HELM_DIR/03-ai-services/llama-guard" -n "$AI_SERVICES_NAMESPACE" \
+                --set device="$DEVICE_TYPE"
         else
             print_warning "llama-guard already installed, skipping..."
         fi


### PR DESCRIPTION
## Xeon Support (SPR+) for LLS Observability
### Core feature
Adds **Intel Xeon CPU as an alternative inference backend** alongside NVIDIA GPU, **controlled by a DEVICE variable (gpu | xeon)**.

---
- This PR extends LLS Observability quick start with an option to deploy whole stack on Intel Xeon CPUs, starting generation 4 (SPR, EMR, GNR) with AVX-512 and AMX support. 
- To deploy the quick start, user needs to specify env variable `DEVICE=xeon', for example:
```bash
DEVICE=xeon ./scripts/install-operators.sh
```
- **IMPORTANT** - this PR also fixes GPU issues with Llama, which causes *llama3-2-3b-predictor* to fail and user can't communicate with LLM using deployed Llama-stack-playground. 
  - I tested it on OpenShift Cluster with GPUs and it fails in the state prior to this PR. 
  - After changes implemented in this PR it works on both: Xeon and GPU configuration
 
**Summary of changes**:
1. **Helm values restructured**: image, resources, tolerations, affinity, nodeSelector, and env in llama3.2-3b and llama-guard are now keyed by device (gpu: / xeon:). Templates use index .Values.<field> $device to select the right block. GPU-only flags (e.g. --gpu_memory_utilization) are conditionally rendered.
2.  **Xeon container image**: New OpenShift BuildConfig builds a vllm-xeon-opentelemetry image with OpenTelemetry packages added.
3. **Chat template extracted**: Moved from baked-in image path to a ConfigMap + volume mount for portability across images.
4. **OTel Collector fixes**: telemetry.metrics.address replaced with level: detailed; Prometheus scrape target port 8080 → 80.
5. **Service URL fixes**: vLLM/safety predictor URLs drop :8080; playground defaults to http://llama-stack-instance-service:8321.
6. **Scripts updated** install-full-stack.sh and deploy-ai-workloads.sh pass --set device="$DEVICE" instead of hardcoded GPU resources; namespace vars now support env overrides.
7. **README**: documents Xeon prerequisites and usage.
